### PR TITLE
Quartus support

### DIFF
--- a/rtl/apb_gpio.sv
+++ b/rtl/apb_gpio.sv
@@ -115,8 +115,9 @@ module apb_gpio
     genvar i;
 
     generate
-        for(i=0;i<PAD_NUM;i++)
+        for(i=0;i<PAD_NUM;i++) begin : GEN_PADCFG
             assign gpio_padcfg[i] = r_gpio_padcfg[i];
+        end
     endgenerate
 
     assign s_apb_addr = PADDR[6:2];


### PR DESCRIPTION
In reference to: pulp-platform/pulpissimo#78

Fixed errors:

- `rtl/apb_gpio.sv`: [unnamed loop generate](https://marekpikula.github.io/quartus-sv-gotchas/Intel%20Quartus%20SystemVerilog%20gotchas.html#274-loop-generate-constructs-3)